### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/HideEmptyTechTreeNodes/Versioning/HideEmptyTechTreeNodes.version
+++ b/GameData/HideEmptyTechTreeNodes/Versioning/HideEmptyTechTreeNodes.version
@@ -1,6 +1,6 @@
 {
     "NAME":"HideEmptyTechTreeNodes",
-    "URL":"https://raw.githubusercontent.com/Orthethac/HideEmptyTechTreeNodes/master/GameData/HideEmptyTechTreeNodes/HideEmptyTechTreeNodes.version",
+    "URL":"https://github.com/Orthethac/HideEmptyTechTreeNodes/raw/master/GameData/HideEmptyTechTreeNodes/Versioning/HideEmptyTechTreeNodes.version",
 	"DOWNLOAD":"https://github.com/Orthethac/HideEmptyTechTreeNodes/releases",
 	"GITHUB":{
         "USERNAME":"Orthethac",


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

Tagging @Orthethac because not everyone has GitHub notifications enabled for pull requests.